### PR TITLE
Gyro drift compensation via zero-motion auto-calibration

### DIFF
--- a/VSCView/MainForm.cs
+++ b/VSCView/MainForm.cs
@@ -76,25 +76,32 @@ namespace VSCView
         private void LoadControllers()
         {
             tsmiController.DropDownItems.Clear();
-
             SteamController[] Controllers = SteamController.GetControllers();
 
-            foreach (SteamController controller in Controllers)
+            for (int i = 0; i < Controllers.Count(); i++)
             {
-                ToolStripItem itm = tsmiController.DropDownItems.Add(controller.GetDevicePath(), null, LoadController);
-                itm.Tag = controller;
+                ToolStripItem itm = tsmiController.DropDownItems.Add(Controllers[i].GetDevicePath(), null, LoadController);
+                itm.Tag = Controllers[i];
+
+                // load the first controller in the list if it exists
+                if (i == 0 && Controllers[i] != null)
+                    LoadController(Controllers[i], null);
             }
         }
 
         private void LoadController(object sender, EventArgs e)
         {
             if (ActiveController != null)
-            {
                 ActiveController.DeInitalize();
-            }
 
-            ToolStripItem item = (ToolStripItem)sender;
-            ActiveController = (SteamController)item.Tag;
+            // differentiate between context selection and startup
+            if (sender is ToolStripItem)
+            {
+                ToolStripItem item = (ToolStripItem)sender;
+                ActiveController = (SteamController)item.Tag;
+            }
+            else
+                ActiveController = (SteamController)sender;
 
             ControllerData.SetController(ActiveController);
             ActiveController.Initalize();

--- a/VSCView/OSD.cs
+++ b/VSCView/OSD.cs
@@ -741,17 +741,17 @@ namespace VSCView
         string ShadowDName;
 
         // provide EMA smoothing for all common IMU outputs
-        SensorFusion.EMACalc qwEMA = new SensorFusion.EMACalc(10);
-        SensorFusion.EMACalc qxEMA = new SensorFusion.EMACalc(10);
-        SensorFusion.EMACalc qyEMA = new SensorFusion.EMACalc(10);
-        SensorFusion.EMACalc qzEMA = new SensorFusion.EMACalc(10);
-        SensorFusion.EMACalc axEMA = new SensorFusion.EMACalc(10);
-        SensorFusion.EMACalc ayEMA = new SensorFusion.EMACalc(10);
-        SensorFusion.EMACalc azEMA = new SensorFusion.EMACalc(10);
-        SensorFusion.EMACalc gxEMA = new SensorFusion.EMACalc(10);
-        SensorFusion.EMACalc gyEMA = new SensorFusion.EMACalc(10);
-        SensorFusion.EMACalc gzEMA = new SensorFusion.EMACalc(10);
-        SensorFusion.OTFCalibrator calib = new SensorFusion.OTFCalibrator(8);
+        SensorFusion.EMACalc qwEMA = new SensorFusion.EMACalc(5);
+        SensorFusion.EMACalc qxEMA = new SensorFusion.EMACalc(5);
+        SensorFusion.EMACalc qyEMA = new SensorFusion.EMACalc(5);
+        SensorFusion.EMACalc qzEMA = new SensorFusion.EMACalc(5);
+        SensorFusion.EMACalc axEMA = new SensorFusion.EMACalc(5);
+        SensorFusion.EMACalc ayEMA = new SensorFusion.EMACalc(5);
+        SensorFusion.EMACalc azEMA = new SensorFusion.EMACalc(5);
+        SensorFusion.EMACalc gxEMA = new SensorFusion.EMACalc(5);
+        SensorFusion.EMACalc gyEMA = new SensorFusion.EMACalc(5);
+        SensorFusion.EMACalc gzEMA = new SensorFusion.EMACalc(5);
+        SensorFusion.OTFCalibrator calib = new SensorFusion.OTFCalibrator(5); // lookback = ~6-8s
 
         protected override void Initalize(ControllerData data, UI_ImageCache cache, string themePath, JObject themeData)
         {
@@ -817,8 +817,8 @@ namespace VSCView
                 double ax = axEMA.NextValue(State.AccelerometerX);
                 double ay = ayEMA.NextValue(State.AccelerometerY);
                 double az = azEMA.NextValue(State.AccelerometerZ);
-                // sensitivity scale factor 4 -> units/g
-                double _ax = ax / 2048 / 16, _ay = ay / 2048 / 16, _az = az / 2048 / 16;
+                // sensitivity scale factor 0 -> units/g
+                double _ax = ax * 1.0f / 16384, _ay = ay * 1.0f / 16384, _az = (az * 1.0f / 16384) - 1;
 
                 float GyroTiltFactorX = (float)gx * 0.0001f;
                 float GyroTiltFactorY = (float)gy * 0.0001f;
@@ -870,7 +870,8 @@ namespace VSCView
 #if DEBUG
                             //Debug.WriteLine($"{TiltFactorY}\t{Roll}\t{(2 * mod(Math.Floor((Roll - 1) * 0.5f) + 1, 2)) - 1}");
                             //Debug.WriteLine($"qW={qw},{qx},{qy},{qz}");
-                            Debug.WriteLine($"{Yaw},{Pitch},{Roll} -> {QuatTiltFactorX},{QuatTiltFactorY},{QuatTiltFactorZ}\r\n");
+                            Debug.WriteLine($"gX={_gx},{_gy},{_gz}\taX={_ax},{_ay},{_az}");
+                            Debug.WriteLine($"{Yaw},{Pitch},{Roll}\r\n");
 #endif
 
                             Draw3dAs3d(cache, graphics, DisplayImage, ShadowLName, ShadowL, ShadowRName, ShadowR, ShadowUName, ShadowU, ShadowDName, ShadowD, transformX, transformY, QuatTiltFactorZ, QuatTiltFactorX, QuatTiltFactorY, Width, Height, TiltTranslateX, TiltTranslateY);

--- a/VSCView/OSD.cs
+++ b/VSCView/OSD.cs
@@ -751,7 +751,7 @@ namespace VSCView
         SensorFusion.EMACalc gxEMA = new SensorFusion.EMACalc(5);
         SensorFusion.EMACalc gyEMA = new SensorFusion.EMACalc(5);
         SensorFusion.EMACalc gzEMA = new SensorFusion.EMACalc(5);
-        SensorFusion.OTFCalibrator calib = new SensorFusion.OTFCalibrator(5); // lookback = ~6-8s
+        SensorFusion.OTFCalibrator calib = new SensorFusion.OTFCalibrator(8); // lookback = ~8-12s
 
         protected override void Initalize(ControllerData data, UI_ImageCache cache, string themePath, JObject themeData)
         {

--- a/VSCView/OSD.cs
+++ b/VSCView/OSD.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
@@ -84,7 +85,7 @@ namespace VSCView
 
     public class ControllerData
     {
-        SteamController ActiveController;
+        public SteamController ActiveController;
 
         public bool GetBasicControl(string inputName)
         {
@@ -794,6 +795,13 @@ namespace VSCView
                 double qy = State.OrientationY * 1.0f / 32768;
                 double qz = State.OrientationZ * 1.0f / 32768;
 
+                double gx = State.AngularVelocityX * 1.0f / 131;
+                double gy = State.AngularVelocityX * 1.0f / 131;
+                double gz = State.AngularVelocityX * 1.0f / 131;
+                double ax = State.AccelerometerX * 1.0f / 32768;
+                double ay = State.AccelerometerY * 1.0f / 32768;
+                double az = State.AccelerometerZ * 1.0f / 32768;
+
                 switch (DisplayType)
                 {
                     case "accel":
@@ -808,6 +816,12 @@ namespace VSCView
                         break;
                     case "gyro":
                         {
+                            if (data.ActiveController.OldState != null &&
+                                data.ActiveController.CheckSensorDataStuck())
+                            {
+                                data.ActiveController.EnableGyroSensors();
+                            }
+
                             double[] eulAnglesYPR = ToEulerAngles(qw, qy, qz, qx);
                             double Yaw = (eulAnglesYPR[0] * 2.0f / Math.PI);
                             double Pitch = (eulAnglesYPR[1] * 2.0f / Math.PI);
@@ -826,6 +840,7 @@ namespace VSCView
                             float transformY = Math.Max(1.0f - Math.Abs(QuatTiltFactorX), 0.15f);
 
                             //Console.WriteLine($"{TiltFactorY}\t{Roll}\t{(2 * mod(Math.Floor((Roll - 1) * 0.5f) + 1, 2)) - 1}");
+                            Debug.WriteLine($"aX={ax},{ay},{az} & gX={gx},{gy},{gz}");
 
                             Draw3dAs3d(cache, graphics, DisplayImage, ShadowLName, ShadowL, ShadowRName, ShadowR, ShadowUName, ShadowU, ShadowDName, ShadowD, transformX, transformY, QuatTiltFactorZ, QuatTiltFactorX, QuatTiltFactorY, Width, Height, TiltTranslateX, TiltTranslateY);
 

--- a/VSCView/SensorFusion.cs
+++ b/VSCView/SensorFusion.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace VSCView
+{
+    public class SensorFusion
+    {
+        public sealed class EMACalc
+        {// adapted from: https://stackoverflow.com/a/44073605
+            readonly double _alpha;
+            double _lastAverage = double.NaN;
+            double _lastVariance = double.NaN;
+            double _lastDataPoint = double.NaN;
+
+            public EMACalc(int lookBack) => _alpha = 2f / (lookBack + 1);
+
+            public double NextValue(double value)
+            {
+                _lastDataPoint = value;
+                return _lastAverage = double.IsNaN(_lastAverage) ?
+                    _lastDataPoint : (_lastDataPoint - _lastAverage) * _alpha + _lastAverage;
+            }
+
+            public double Deviation() => _lastVariance = double.IsNaN(_lastVariance) ?
+                0f : Math.Sqrt(_alpha * Math.Pow(_lastDataPoint - _lastAverage, 2) + (1 - _alpha) * Math.Pow(_lastVariance, 2));
+        }
+
+        public sealed class OTFCalibrator
+        {
+            public double OffsetY { get; private set; }
+            public double OffsetP { get; private set; }
+            public double OffsetR { get; private set; }
+
+            EMACalc velocity, velEMA;
+            int SampleSize, OffsetThreshold;
+            double _lastEMD;
+
+            /// <summary>
+            /// Calculates an offset for IMU data streams (YPR/AHR) using a timer and zero-point diffing
+            /// </summary>
+            /// <param name="bufferTime">Seconds to buffer before calculating offset</param>
+            public OTFCalibrator(int bufferTime)
+            {
+                OffsetY = 0f;
+                OffsetP = 0f;
+                OffsetR = 0f;
+                SampleSize = (int)(66.667f * bufferTime); // timer paints at ~66fps x buffer window (s)
+                OffsetThreshold = SampleSize;
+                velocity = new EMACalc(SampleSize);
+                velEMA = new EMACalc(bufferTime);
+            }
+
+            /// <summary>
+            /// Uses raw IMU sensor data to determine if sensors are idle so offsets for AHR can be calculated
+            /// </summary>
+            /// <param name="yaw">Heading input to calculate the offset for</param>
+            /// <param name="pitch">Pitch input to calculate the offset for</param>
+            /// <param name="roll">Roll input to calculate the offset for</param>
+            /// <param name="gx">Raw Gyro data of the X axis in degree seconds</param>
+            /// <param name="gy">Raw Gyro data of the Y axis in degree seconds</param>
+            /// <param name="gz">Raw Gyro data of the Z axis in degree seconds</param>
+            /// <param name="ax">Raw Accelerometer data of the X axis</param>
+            /// <param name="ay">Raw Accelerometer data of the Y axis</param>
+            /// <param name="ay">Raw Accelerometer data of the Z axis</param>
+            public void Calibrate(double yaw, double pitch, double roll,
+                double gx, double gy, double gz, double ax, double ay, double az)
+            {
+                // use the normalized sum of gyro and accel readings to derive idle
+                double normGyro = Math.Sqrt(gx * gx + gy * gy + gz * gz);
+                double normAccel = Math.Sqrt(ax * ax + ay * ay + az * az);
+                velocity.NextValue(normGyro + normAccel);
+                double velEMD = velEMA.NextValue(velocity.Deviation());
+                float floor = 0.01f, ceiling = 0.5f;
+
+#if DEBUG
+                Debug.WriteLine($"[ {ax},{ay},{az} ] => {velEMD} = [ {OffsetY},{OffsetP},{OffsetR} ]");
+#endif
+
+                if (OffsetThreshold == SampleSize)
+                {// if full offset then reset the counter
+                    OffsetY = 1.0f - 1.0f - yaw;
+                    OffsetP = 1.0f - 1.0f - pitch;
+                    OffsetR = 1.0f - 1.0f - roll;
+                    OffsetThreshold = 0;
+                }
+
+                // only collect when emd acceleration velocities are very near idle
+                if ((_lastEMD > floor && _lastEMD <= ceiling) && (velEMD > floor && velEMD <= ceiling))
+                    OffsetThreshold++;
+                else
+                    OffsetThreshold = 0;
+
+                _lastEMD = velEMD;
+            }
+        }
+    }
+}

--- a/VSCView/SteamController.cs
+++ b/VSCView/SteamController.cs
@@ -134,6 +134,8 @@ namespace VSCView
             public Int16 OrientationX { get; set; }
             public Int16 OrientationY { get; set; }
             public Int16 OrientationZ { get; set; }
+
+            public Int32 Timestamp { get; set; }
         }
 
         SteamControllerButtons Buttons { get; set; }
@@ -161,6 +163,8 @@ namespace VSCView
         Int16 OrientationX { get; set; }
         Int16 OrientationY { get; set; }
         Int16 OrientationZ { get; set; }
+
+        public Int32 Timestamp { get; set; }
 
         bool Initalized;
 
@@ -297,6 +301,8 @@ namespace VSCView
                 state.OrientationY = OrientationY;
                 state.OrientationZ = OrientationZ;
 
+                state.Timestamp = Timestamp;
+
                 return state;
             }
         }
@@ -428,6 +434,8 @@ namespace VSCView
                             OrientationX = BitConverter.ToInt16(report.Data, 42);
                             OrientationY = BitConverter.ToInt16(report.Data, 44);
                             OrientationZ = BitConverter.ToInt16(report.Data, 46);
+
+                            Timestamp = DateTime.Now.Millisecond;
                         }
                         break;
 

--- a/VSCView/SteamController.cs
+++ b/VSCView/SteamController.cs
@@ -42,9 +42,11 @@ namespace VSCView
 
             public bool LeftBumper { get; set; }
             public bool LeftTrigger { get; set; }
+            public bool LeftTriggerAnalog { get; set; }
 
             public bool RightBumper { get; set; }
             public bool RightTrigger { get; set; }
+            public bool RightTriggerAnalog { get; set; }
 
             public bool LeftGrip { get; set; }
             public bool RightGrip { get; set; }
@@ -75,9 +77,11 @@ namespace VSCView
 
                 buttons.LeftBumper = LeftBumper;
                 buttons.LeftTrigger = LeftTrigger;
+                buttons.LeftTriggerAnalog = LeftTriggerAnalog;
 
                 buttons.RightBumper = RightBumper;
                 buttons.RightTrigger = RightTrigger;
+                buttons.RightTriggerAnalog = RightTriggerAnalog;
 
                 buttons.LeftGrip = LeftGrip;
                 buttons.RightGrip = RightGrip;
@@ -108,6 +112,9 @@ namespace VSCView
             public byte LeftTrigger { get; set; }
             public byte RightTrigger { get; set; }
 
+            public bool LeftTriggerAnalog { get; set; }
+            public bool RightTriggerAnalog { get; set; }
+
             public Int32 LeftStickX { get; set; }
             public Int32 LeftStickY { get; set; }
             public Int32 LeftPadX { get; set; }
@@ -128,6 +135,9 @@ namespace VSCView
 
         byte LeftTrigger { get; set; }
         byte RightTrigger { get; set; }
+
+        bool LeftTriggerAnalog { get; set; }
+        bool RightTriggerAnalog { get; set; }
 
         Int32 LeftStickX { get; set; }
         Int32 LeftStickY { get; set; }
@@ -212,6 +222,8 @@ namespace VSCView
 
                 state.LeftTrigger = LeftTrigger;
                 state.RightTrigger = RightTrigger;
+                state.LeftTriggerAnalog = LeftTriggerAnalog;
+                state.RightTriggerAnalog = RightTriggerAnalog;
 
                 state.LeftStickX = LeftStickX;
                 state.LeftStickY = LeftStickY;
@@ -307,6 +319,10 @@ namespace VSCView
 
                             LeftTrigger = report.Data[11];
                             RightTrigger = report.Data[12];
+
+                            // use 20% of analog range (0-255) for minimum threshold
+                            LeftTriggerAnalog = LeftTrigger > (255 * 0.20);
+                            RightTriggerAnalog = RightTrigger > (255 * 0.20);
 
                             if (LeftAnalogMultiplexMode)
                             {

--- a/VSCView/SteamController.cs
+++ b/VSCView/SteamController.cs
@@ -16,6 +16,8 @@ namespace VSCView
         private const int ProductIdWireless = 0x1142; // 4418;
         private const int ProductIdWired = 0x1102; // 4354
 
+        public SteamControllerState OldState;
+
         //private bool _attached = false;
         private HidDevice _device;
 
@@ -277,6 +279,7 @@ namespace VSCView
             lock (controllerStateLock)
             {
                 //SteamControllerState OldState = GetState();
+                OldState = GetState();
 
                 //if (_attached == false) { return; }
 
@@ -378,7 +381,14 @@ namespace VSCView
                             OrientationY = BitConverter.ToInt16(report.Data, 44);
                             OrientationZ = BitConverter.ToInt16(report.Data, 46);
 
-                            if (AccelerometerZ > 0)
+                            if (OldState.AccelerometerX == AccelerometerX &&
+                                OldState.AccelerometerY == AccelerometerY &&
+                                OldState.AccelerometerZ == AccelerometerZ)
+                            {
+                                Debug.WriteLine($"Accelerometer is not enabled or sensor data is stuck!");
+                                // DO STUFF HERE
+                            }
+                            else if (AccelerometerZ > 0)
                                 Debug.WriteLine($"aX={AccelerometerX},{AccelerometerY},{AccelerometerZ}");
                         }
                         break;

--- a/VSCView/SteamController.cs
+++ b/VSCView/SteamController.cs
@@ -122,6 +122,9 @@ namespace VSCView
             public Int32 RightPadX { get; set; }
             public Int32 RightPadY { get; set; }
 
+            public Int16 AccelerometerX { get; set; }
+            public Int16 AccelerometerY { get; set; }
+            public Int16 AccelerometerZ { get; set; }
             public Int16 AngularVelocityX { get; set; }
             public Int16 AngularVelocityY { get; set; }
             public Int16 AngularVelocityZ { get; set; }
@@ -146,6 +149,9 @@ namespace VSCView
         Int32 RightPadX { get; set; }
         Int32 RightPadY { get; set; }
 
+        Int16 AccelerometerX { get; set; }
+        Int16 AccelerometerY { get; set; }
+        Int16 AccelerometerZ { get; set; }
         Int16 AngularVelocityX { get; set; }
         Int16 AngularVelocityY { get; set; }
         Int16 AngularVelocityZ { get; set; }
@@ -190,10 +196,6 @@ namespace VSCView
             //_attached = _device.IsConnected;
 
             _device.ReadReport(OnReport);
-
-            // enable gyro and accel data when wired
-            //_device.WriteFeatureData(new byte[] { 0x30 | 0x04 | 0x08 | 0x10 });
-            //Thread.Sleep(20); // prevent EPIPE hang
         }
 
         public void DeInitalize()
@@ -232,6 +234,9 @@ namespace VSCView
                 state.RightPadX = RightPadX;
                 state.RightPadY = RightPadY;
 
+                state.AccelerometerX = AccelerometerX;
+                state.AccelerometerY = AccelerometerY;
+                state.AccelerometerZ = AccelerometerZ;
                 state.AngularVelocityX = AngularVelocityX;
                 state.AngularVelocityY = AngularVelocityY;
                 state.AngularVelocityZ = AngularVelocityZ;
@@ -362,14 +367,9 @@ namespace VSCView
                             RightPadX = BitConverter.ToInt16(report.Data, 20);
                             RightPadY = BitConverter.ToInt16(report.Data, 22);
 
-                            /*
-                            //NiceOutputText[28] += " -------- Acceleration X: " + BitConverter.ToInt16(report.Data, 28);
-                            //NiceOutputText[29] += " ^^^^^^^^";
-                            //NiceOutputText[30] += " -------- Acceleration Y: " + BitConverter.ToInt16(report.Data, 30);
-                            //NiceOutputText[31] += " ^^^^^^^^";
-                            //NiceOutputText[32] += " -------- Acceleration Z: " + BitConverter.ToInt16(report.Data, 32);
-                            //NiceOutputText[33] += " ^^^^^^^^";
-                            */
+                            AccelerometerX = BitConverter.ToInt16(report.Data, 28);
+                            AccelerometerY = BitConverter.ToInt16(report.Data, 30);
+                            AccelerometerZ = BitConverter.ToInt16(report.Data, 32);
                             AngularVelocityX = BitConverter.ToInt16(report.Data, 34);
                             AngularVelocityY = BitConverter.ToInt16(report.Data, 36);
                             AngularVelocityZ = BitConverter.ToInt16(report.Data, 38);
@@ -377,6 +377,9 @@ namespace VSCView
                             OrientationX = BitConverter.ToInt16(report.Data, 42);
                             OrientationY = BitConverter.ToInt16(report.Data, 44);
                             OrientationZ = BitConverter.ToInt16(report.Data, 46);
+
+                            if (AccelerometerZ > 0)
+                                Debug.WriteLine($"aX={AccelerometerX},{AccelerometerY},{AccelerometerZ}");
                         }
                         break;
 

--- a/VSCView/VSCView.csproj
+++ b/VSCView/VSCView.csproj
@@ -69,6 +69,7 @@
     <Compile Include="ProcForm.Designer.cs">
       <DependentUpon>ProcForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="SensorFusion.cs" />
     <Compile Include="SteamController.cs" />
     <Compile Include="RawForm.cs">
       <SubType>Form</SubType>

--- a/VSCView/VSCView.csproj
+++ b/VSCView/VSCView.csproj
@@ -34,8 +34,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/VSCView/packages.config
+++ b/VSCView/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
This is my second attempt to implement gyro drift compensation. After trying many other methods since my last attempt I came to some success with this latest method (zero-motion detection to calculate bias offset). This type of drift compensation method was recommended by one of the Valve developers. What follows is my own implementation of an attempt to duplicate Valve's auto-calibration. My algorithm works like this:

1) Gather gyro and accelerometer samples then feed them into an EMA filter.
2) Normalize the sensor samples per sample period and feed them into another EMA filter.
3) Calculate EMD and Z-Score off this smoothed sensor magnitude input.
4) Use movement : threshold comparison, Z-Score : EMD comparison, and finally local maxima search (peak detection) to arrive at a standing activity reading of the sensors.
5) When idle is detected from Step 4, accumulate up to a set number of samples (in seconds, generally about 6-8), then calculate the corrected AHR (Yaw, Pitch, Roll) bias for use in the renderer.

I also fixed the USB device enumeration issue by borrowing the linux driver's approach to determining which of the SC bus devices is the correct one and using it automatically. This should also display multiple SC devices properly in the device selection menu now.

Let me know if you have any particular constructive criticisms, and I'll try my best to address them as soon as I'm able.

(Updated as of 5/6/19: made additional improvements to the zero-detection algorithm. This should be my final commit for this PR.)

(Update as of 5/7/19: I noticed after some more testing that having the smoothing logic inside one of the Paint() calls was causing nutty performance issues on lower spec machines. I'm in the process of splitting up the rendering and input sampling logic.)