### PR TITLE
Refactoring and performance optimizations for rendering to OnPaint

### DIFF
--- a/VSCView/MainForm.Designer.cs
+++ b/VSCView/MainForm.Designer.cs
@@ -29,7 +29,6 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            this.tmrPaint = new System.Windows.Forms.Timer(this.components);
             this.cmsMain = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.tsmiTheme = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiController = new System.Windows.Forms.ToolStripMenuItem();
@@ -47,14 +46,9 @@
             this.cmsMain.SuspendLayout();
             this.SuspendLayout();
             // 
-            // tmrPaint
-            // 
-            this.tmrPaint.Enabled = true;
-            this.tmrPaint.Interval = 15;
-            this.tmrPaint.Tick += new System.EventHandler(this.tmrPaint_Tick);
-            // 
             // cmsMain
             // 
+            this.cmsMain.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.cmsMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.tsmiTheme,
             this.tsmiController,
@@ -67,85 +61,87 @@
             this.toolStripSeparator3,
             this.tsmiExit});
             this.cmsMain.Name = "cmsMain";
-            this.cmsMain.Size = new System.Drawing.Size(190, 176);
+            this.cmsMain.Size = new System.Drawing.Size(223, 190);
             // 
             // tsmiTheme
             // 
             this.tsmiTheme.Name = "tsmiTheme";
-            this.tsmiTheme.Size = new System.Drawing.Size(189, 22);
+            this.tsmiTheme.Size = new System.Drawing.Size(222, 24);
             this.tsmiTheme.Text = "&Theme";
             // 
             // tsmiController
             // 
             this.tsmiController.Name = "tsmiController";
-            this.tsmiController.Size = new System.Drawing.Size(189, 22);
+            this.tsmiController.Size = new System.Drawing.Size(222, 24);
             this.tsmiController.Text = "&Controller";
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(186, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(219, 6);
             // 
             // tsmiReloadThemes
             // 
             this.tsmiReloadThemes.Name = "tsmiReloadThemes";
-            this.tsmiReloadThemes.Size = new System.Drawing.Size(189, 22);
+            this.tsmiReloadThemes.Size = new System.Drawing.Size(222, 24);
             this.tsmiReloadThemes.Text = "Reload Themes";
             this.tsmiReloadThemes.Click += new System.EventHandler(this.tsmiReloadThemes_Click);
             // 
             // tsmiReloadControllers
             // 
             this.tsmiReloadControllers.Name = "tsmiReloadControllers";
-            this.tsmiReloadControllers.Size = new System.Drawing.Size(189, 22);
+            this.tsmiReloadControllers.Size = new System.Drawing.Size(222, 24);
             this.tsmiReloadControllers.Text = "Reload Controllers";
             this.tsmiReloadControllers.Click += new System.EventHandler(this.tsmiReloadControllers_Click);
             // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(186, 6);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(219, 6);
             // 
             // tsmiSetBackgroundColor
             // 
             this.tsmiSetBackgroundColor.Name = "tsmiSetBackgroundColor";
-            this.tsmiSetBackgroundColor.Size = new System.Drawing.Size(189, 22);
+            this.tsmiSetBackgroundColor.Size = new System.Drawing.Size(222, 24);
             this.tsmiSetBackgroundColor.Text = "Set Background Color";
             this.tsmiSetBackgroundColor.Click += new System.EventHandler(this.tsmiSetBackgroundColor_Click);
             // 
             // tsmiAbout
             // 
             this.tsmiAbout.Name = "tsmiAbout";
-            this.tsmiAbout.Size = new System.Drawing.Size(189, 22);
+            this.tsmiAbout.Size = new System.Drawing.Size(222, 24);
             this.tsmiAbout.Text = "&About";
             this.tsmiAbout.Click += new System.EventHandler(this.tsmiAbout_Click);
             // 
             // toolStripSeparator3
             // 
             this.toolStripSeparator3.Name = "toolStripSeparator3";
-            this.toolStripSeparator3.Size = new System.Drawing.Size(186, 6);
+            this.toolStripSeparator3.Size = new System.Drawing.Size(219, 6);
             // 
             // tsmiExit
             // 
             this.tsmiExit.Name = "tsmiExit";
-            this.tsmiExit.Size = new System.Drawing.Size(189, 22);
+            this.tsmiExit.Size = new System.Drawing.Size(222, 24);
             this.tsmiExit.Text = "E&xit";
             this.tsmiExit.Click += new System.EventHandler(this.tsmiExit_Click);
             // 
             // lblHint1
             // 
             this.lblHint1.AutoSize = true;
-            this.lblHint1.Location = new System.Drawing.Point(87, 77);
+            this.lblHint1.Location = new System.Drawing.Point(116, 95);
+            this.lblHint1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblHint1.Name = "lblHint1";
-            this.lblHint1.Size = new System.Drawing.Size(142, 13);
+            this.lblHint1.Size = new System.Drawing.Size(185, 17);
             this.lblHint1.TabIndex = 1;
             this.lblHint1.Text = "Right Click for Context Menu";
             // 
             // lblHint2
             // 
             this.lblHint2.AutoSize = true;
-            this.lblHint2.Location = new System.Drawing.Point(87, 109);
+            this.lblHint2.Location = new System.Drawing.Point(116, 134);
+            this.lblHint2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblHint2.Name = "lblHint2";
-            this.lblHint2.Size = new System.Drawing.Size(119, 13);
+            this.lblHint2.Size = new System.Drawing.Size(154, 17);
             this.lblHint2.TabIndex = 2;
             this.lblHint2.Text = "Click and Drag to Move";
             // 
@@ -155,17 +151,19 @@
             // 
             // MainForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.Lime;
-            this.ClientSize = new System.Drawing.Size(314, 264);
+            this.ClientSize = new System.Drawing.Size(419, 325);
             this.ContextMenuStrip = this.cmsMain;
             this.Controls.Add(this.lblHint2);
             this.Controls.Add(this.lblHint1);
             this.DoubleBuffered = true;
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "MainForm";
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.Text = "VSCView";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.MainForm_FormClosed);
             this.MouseDown += new System.Windows.Forms.MouseEventHandler(this.MainForm_MouseDown);
             this.cmsMain.ResumeLayout(false);
             this.ResumeLayout(false);
@@ -174,8 +172,6 @@
         }
 
         #endregion
-
-        private System.Windows.Forms.Timer tmrPaint;
         private System.Windows.Forms.ContextMenuStrip cmsMain;
         private System.Windows.Forms.ToolStripMenuItem tsmiTheme;
         private System.Windows.Forms.ToolStripMenuItem tsmiController;

--- a/VSCView/MainForm.resx
+++ b/VSCView/MainForm.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="tmrPaint.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
   <metadata name="cmsMain.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>115, 17</value>
   </metadata>

--- a/VSCView/OSD.cs
+++ b/VSCView/OSD.cs
@@ -7,8 +7,6 @@ using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace VSCView
 {
@@ -170,6 +168,7 @@ namespace VSCView
             inputName = inputName.ToLowerInvariant();
 
             SteamController.SteamControllerState state = ActiveController.GetState();
+            var sensorData = MainForm.sensorData.Data;
 
             switch (inputName)
             {
@@ -184,12 +183,6 @@ namespace VSCView
 
                 case "lefttrigger": return state.LeftTrigger;
                 case "righttrigger": return state.RightTrigger;
-
-                case "angularvelocityx": return state.AngularVelocityX;
-                case "angularvelocityy": return state.AngularVelocityY;
-                case "angularvelocityz": return state.AngularVelocityZ;
-
-                // consider orientation data here, but it's a quaternion so that's complicated
 
                 default: return 0;
             }
@@ -740,19 +733,6 @@ namespace VSCView
         string ShadowUName;
         string ShadowDName;
 
-        // provide EMA smoothing for all common IMU outputs
-        SensorFusion.EMACalc qwEMA = new SensorFusion.EMACalc(5);
-        SensorFusion.EMACalc qxEMA = new SensorFusion.EMACalc(5);
-        SensorFusion.EMACalc qyEMA = new SensorFusion.EMACalc(5);
-        SensorFusion.EMACalc qzEMA = new SensorFusion.EMACalc(5);
-        SensorFusion.EMACalc axEMA = new SensorFusion.EMACalc(5);
-        SensorFusion.EMACalc ayEMA = new SensorFusion.EMACalc(5);
-        SensorFusion.EMACalc azEMA = new SensorFusion.EMACalc(5);
-        SensorFusion.EMACalc gxEMA = new SensorFusion.EMACalc(5);
-        SensorFusion.EMACalc gyEMA = new SensorFusion.EMACalc(5);
-        SensorFusion.EMACalc gzEMA = new SensorFusion.EMACalc(5);
-        SensorFusion.OTFCalibrator calib = new SensorFusion.OTFCalibrator(8); // lookback = ~8-12s
-
         protected override void Initalize(ControllerData data, UI_ImageCache cache, string themePath, JObject themeData)
         {
             base.Initalize(data, cache, themePath, themeData);
@@ -793,88 +773,45 @@ namespace VSCView
             Matrix preserve = graphics.Transform;
 
             graphics.TranslateTransform(X, Y);
-            //graphics.TranslateTransform(-Width / 2, -Height / 2);
 
-            SteamController.SteamControllerState State = data.GetState();
-            SteamController.SteamControllerState prevState = data.ActiveController.OldState;
+            var sensorData = MainForm.sensorData.Data; // use the cache!
 
-            if (State != null)
+            if (sensorData != null)
             {
-                //float dt = prevState != null ? (State.Timestamp - prevState.Timestamp) / 1000 : 0.008f;
-                double deg2rad = Math.PI / 180.0f, rad2deg = 1 / deg2rad;
-                double qw = qwEMA.NextValue(State.OrientationW);
-                double qx = qxEMA.NextValue(State.OrientationX);
-                double qy = qyEMA.NextValue(State.OrientationY);
-                double qz = qzEMA.NextValue(State.OrientationZ);
-                double _qw = qw * 1.0f / 32768, _qx = qx * 1.0f / 32768, _qy = qy * 1.0f / 32768, _qz = qz * 1.0f / 32768;
-
-                double gx = gxEMA.NextValue(State.AngularVelocityX);
-                double gy = gyEMA.NextValue(State.AngularVelocityY);
-                double gz = gzEMA.NextValue(State.AngularVelocityZ);
-                // sensitivity scale factor 4 -> radian/sec
-                double _gx = gx / 16.4f * deg2rad, _gy = gy / 16.4f * deg2rad, _gz = gz / 16.4f * deg2rad;
-
-                double ax = axEMA.NextValue(State.AccelerometerX);
-                double ay = ayEMA.NextValue(State.AccelerometerY);
-                double az = azEMA.NextValue(State.AccelerometerZ);
-                // sensitivity scale factor 0 -> units/g
-                double _ax = ax * 1.0f / 16384, _ay = ay * 1.0f / 16384, _az = (az * 1.0f / 16384) - 1;
-
-                float GyroTiltFactorX = (float)gx * 0.0001f;
-                float GyroTiltFactorY = (float)gy * 0.0001f;
-                float GyroTiltFactorZ = (float)gz * 0.0001f * -90;
-
                 switch (DisplayType)
                 {
                     case "accel":
                         {
-                            float transformX = 1.0f - Math.Abs(GyroTiltFactorY * 0.5f);
-                            float transformY = 1.0f - Math.Abs(GyroTiltFactorX * 0.5f);
+                            float transformX = 1.0f - Math.Abs(sensorData.GyroTiltFactorY * 0.5f);
+                            float transformY = 1.0f - Math.Abs(sensorData.GyroTiltFactorX * 0.5f);
 
-                            Draw3dAs3d(cache, graphics, DisplayImage, ShadowLName, ShadowL, ShadowRName, ShadowR, ShadowUName, ShadowU, ShadowDName, ShadowD, transformX, transformY, GyroTiltFactorZ, GyroTiltFactorX, GyroTiltFactorY, Width, Height, TiltTranslateX, TiltTranslateY);
+                            Draw3dAs3d(
+                                cache, graphics, DisplayImage, ShadowLName, ShadowL, ShadowRName, ShadowR, ShadowUName, ShadowU, ShadowDName, ShadowD,
+                                transformX, transformY, sensorData.GyroTiltFactorZ, sensorData.GyroTiltFactorX, sensorData.GyroTiltFactorY,
+                                Width, Height, TiltTranslateX, TiltTranslateY
+                            );
 
                             graphics.ResetTransform();
                         }
                         break;
                     case "gyro":
                         {
-                            if (data.ActiveController.OldState != null &&
-                                data.ActiveController.CheckSensorDataStuck())
-                            {
-                                data.ActiveController.EnableGyroSensors();
-                            }
-
-                            double[] eulAnglesYPR = ToEulerAngles(_qw, _qy, _qz, _qx);
-                            double Yaw = eulAnglesYPR[0] * 2.0f / Math.PI;
-                            double Pitch = eulAnglesYPR[1] * 2.0f / Math.PI;
-                            double Roll = -(eulAnglesYPR[2] * 2.0f / Math.PI);
-
-                            if (double.IsNaN(Yaw)) Yaw = 0f;
-                            if (double.IsNaN(Pitch)) Pitch = 0f;
-                            if (double.IsNaN(Roll)) Roll = 0f;
-
-                            // auto-calibrate on the fly over several seconds when near idle
-                            calib.Calibrate(Yaw, Pitch, Roll, _gx, _gy, _gz, _ax, _ay, _az);
-                            Yaw += calib.OffsetY;
-                            Pitch += calib.OffsetP;
-                            Roll += calib.OffsetR;
-
-                            int SignY = -Math.Sign((2 * mod(Math.Floor((Roll - 1) * 0.5f) + 1, 2)) - 1);
-                            float QuatTiltFactorX = (float)((2 * Math.Abs(mod((Pitch - 1) * 0.5f, 2) - 1)) - 1);
-                            float QuatTiltFactorY = (float)((2 * Math.Abs(mod((Roll - 1) * 0.5f, 2) - 1)) - 1);
-                            float QuatTiltFactorZ = (float)(Yaw * -90.0f);
-
-                            float transformX = SignY * Math.Max(1.0f - Math.Abs(QuatTiltFactorY), 0.15f);
-                            float transformY = Math.Max(1.0f - Math.Abs(QuatTiltFactorX), 0.15f);
+                            int SignY = -Math.Sign((2 * SensorCollector.Mod(Math.Floor((sensorData.Roll - 1) * 0.5f) + 1, 2)) - 1);
+                            float transformX = SignY * Math.Max(1.0f - Math.Abs(sensorData.QuatTiltFactorY), 0.15f);
+                            float transformY = Math.Max(1.0f - Math.Abs(sensorData.QuatTiltFactorX), 0.15f);
 
 #if DEBUG
                             //Debug.WriteLine($"{TiltFactorY}\t{Roll}\t{(2 * mod(Math.Floor((Roll - 1) * 0.5f) + 1, 2)) - 1}");
                             //Debug.WriteLine($"qW={qw},{qx},{qy},{qz}");
-                            Debug.WriteLine($"gX={_gx},{_gy},{_gz}\taX={_ax},{_ay},{_az}");
-                            Debug.WriteLine($"{Yaw},{Pitch},{Roll}\r\n");
+                            //Debug.WriteLine($"gX={_gx},{_gy},{_gz}\taX={_ax},{_ay},{_az}");
+                            //Debug.WriteLine($"{sensorData.Yaw},{sensorData.Pitch},{sensorData.Roll}\r\n");
 #endif
 
-                            Draw3dAs3d(cache, graphics, DisplayImage, ShadowLName, ShadowL, ShadowRName, ShadowR, ShadowUName, ShadowU, ShadowDName, ShadowD, transformX, transformY, QuatTiltFactorZ, QuatTiltFactorX, QuatTiltFactorY, Width, Height, TiltTranslateX, TiltTranslateY);
+                            Draw3dAs3d(
+                                cache, graphics, DisplayImage, ShadowLName, ShadowL, ShadowRName, ShadowR, ShadowUName, ShadowU, ShadowDName, ShadowD,
+                                transformX, transformY, sensorData.QuatTiltFactorZ, sensorData.QuatTiltFactorX, sensorData.QuatTiltFactorY,
+                                Width, Height, TiltTranslateX, TiltTranslateY
+                            );
 
                             graphics.ResetTransform();
                         }
@@ -885,52 +822,6 @@ namespace VSCView
             }
 
             graphics.Transform = preserve;
-            
-            base.Paint(graphics);
-        }
-
-        public static double[] ToEulerAngles(double QuaternionW, double QuaternionX, double QuaternionY, double QuaternionZ)
-        {
-            double sqw = QuaternionW * QuaternionW;
-            double sqx = QuaternionX * QuaternionX;
-            double sqy = QuaternionY * QuaternionY;
-            double sqz = QuaternionZ * QuaternionZ;
-
-            // If quaternion is normalised the unit is one, otherwise it is the correction factor
-            double unit = sqx + sqy + sqz + sqw;
-            double test = QuaternionX * QuaternionY + QuaternionZ * QuaternionW;
-
-            if (test > 0.4999f * unit)                              // 0.4999f OR 0.5f - EPSILON
-            {
-                // Singularity at north pole
-                return new double[] {
-                    2f * Math.Atan2(QuaternionX, QuaternionW),  // Yaw
-                    Math.PI * 0.5f,                         // Pitch
-                    0f                                // Roll
-                };
-            }
-            else if (test < -0.4999f * unit)                        // -0.4999f OR -0.5f + EPSILON
-            {
-                // Singularity at south pole
-                return new double[] {
-                    -2f * Math.Atan2(QuaternionX, QuaternionW), // Yaw
-                    -Math.PI * 0.5f,                        // Pitch
-                    0f                                // Roll
-                };
-            }
-            else
-            {
-                return new double[] {
-                    Math.Atan2(2f * QuaternionY * QuaternionW - 2f * QuaternionX * QuaternionZ, sqx - sqy - sqz + sqw),       // Yaw
-                    Math.Asin(2f * test / unit),                                             // Pitch
-                    Math.Atan2(2f * QuaternionX * QuaternionW - 2f * QuaternionY * QuaternionZ, -sqx + sqy - sqz + sqw)      // Roll
-                };
-            }
-        }
-
-        double mod(double x, double m)
-        {
-            return (x % m + m) % m;
         }
 
         private void Draw3dAs3d(

--- a/VSCView/Program.cs
+++ b/VSCView/Program.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace VSCView

--- a/VSCView/SensorCollector.cs
+++ b/VSCView/SensorCollector.cs
@@ -1,0 +1,205 @@
+﻿using System;
+using System.Threading;
+
+namespace VSCView
+{
+    /// <summary>
+    /// Functions as both a cache for sensor data and a filter for auto-calibration
+    /// </summary>
+    public sealed class SensorCollector
+    {
+        public class SensorData
+        {// data struct for SensorCollector
+            public int gX = 0;
+            public int gY = 0;
+            public int gZ = 0;
+
+            public int aX = 0;
+            public int aY = 0;
+            public int aZ = 0;
+
+            public double qW = 0f;
+            public double qX = 0f;
+            public double qY = 0f;
+            public double qZ = 0f;
+
+            public double calGyroX = 0f;
+            public double calGyroY = 0f;
+            public double calGyroZ = 0f;
+
+            public double calAccelX = 0f;
+            public double calAccelY = 0f;
+            public double calAccelZ = 0f;
+
+            public double Yaw = 0f;
+            public double Pitch = 0f;
+            public double Roll = 0f;
+
+            public float GyroTiltFactorX = 0f;
+            public float GyroTiltFactorY = 0f;
+            public float GyroTiltFactorZ = 0f;
+            public float QuatTiltFactorX = 0f;
+            public float QuatTiltFactorY = 0f;
+            public float QuatTiltFactorZ = 0f;
+        }
+
+        public SensorData Data { get; private set; }
+
+        const double deg2rad = 0.01745329251994329577f;
+        int Lookback = 0, usingResource = 0;
+        bool Smoothing;
+        SensorFusion.EMACalc qwEMA;
+        SensorFusion.EMACalc qxEMA;
+        SensorFusion.EMACalc qyEMA;
+        SensorFusion.EMACalc qzEMA;
+
+        SensorFusion.EMACalc gxEMA;
+        SensorFusion.EMACalc gyEMA;
+        SensorFusion.EMACalc gzEMA;
+
+        SensorFusion.EMACalc axEMA;
+        SensorFusion.EMACalc ayEMA;
+        SensorFusion.EMACalc azEMA;
+
+        SensorFusion.OTFCalibrator calib = new SensorFusion.OTFCalibrator(8); // buffer ~8-10s
+
+        public SensorCollector(int lookback, bool smoothing)
+        {
+            Lookback = lookback;
+            Smoothing = smoothing;
+            qwEMA = new SensorFusion.EMACalc(Lookback);
+            qxEMA = new SensorFusion.EMACalc(Lookback);
+            qyEMA = new SensorFusion.EMACalc(Lookback);
+            qzEMA = new SensorFusion.EMACalc(Lookback);
+
+            gxEMA = new SensorFusion.EMACalc(Lookback);
+            gyEMA = new SensorFusion.EMACalc(Lookback);
+            gzEMA = new SensorFusion.EMACalc(Lookback);
+
+            axEMA = new SensorFusion.EMACalc(Lookback);
+            ayEMA = new SensorFusion.EMACalc(Lookback);
+            azEMA = new SensorFusion.EMACalc(Lookback);
+            Data = new SensorData();
+        }
+
+        public SensorData Update(SteamController.SteamControllerState stateData)
+        {// atomic updates
+            if (0 == Interlocked.Exchange(ref usingResource, 1))
+            {
+                Data = new SensorData();
+                if (Smoothing)
+                {
+                    Data.qW = qwEMA.NextValue(stateData.OrientationW * 1.0f / 32768);
+                    Data.qX = qxEMA.NextValue(stateData.OrientationX * 1.0f / 32768);
+                    Data.qY = qyEMA.NextValue(stateData.OrientationY * 1.0f / 32768);
+                    Data.qZ = qzEMA.NextValue(stateData.OrientationZ * 1.0f / 32768);
+
+                    Data.gX = (int)gxEMA.NextValue(stateData.AngularVelocityX);
+                    Data.gY = (int)gyEMA.NextValue(stateData.AngularVelocityY);
+                    Data.gZ = (int)gzEMA.NextValue(stateData.AngularVelocityZ);
+
+                    Data.aX = (int)axEMA.NextValue(stateData.AccelerometerX);
+                    Data.aY = (int)ayEMA.NextValue(stateData.AccelerometerY);
+                    Data.aZ = (int)azEMA.NextValue(stateData.AccelerometerZ);
+                }
+                else if (stateData != null)
+                {
+                    Data.qW = stateData.OrientationW * 1.0f / 32768;
+                    Data.qX = stateData.OrientationX * 1.0f / 32768;
+                    Data.qY = stateData.OrientationY * 1.0f / 32768;
+                    Data.qZ = stateData.OrientationZ * 1.0f / 32768;
+
+                    Data.gX = stateData.AngularVelocityX;
+                    Data.gY = stateData.AngularVelocityY;
+                    Data.gZ = stateData.AngularVelocityZ;
+
+                    Data.aX = stateData.AccelerometerX;
+                    Data.aY = stateData.AccelerometerY;
+                    Data.aZ = stateData.AccelerometerZ;
+                }
+
+                Data.GyroTiltFactorX = (float)Data.gX * 0.0001f;
+                Data.GyroTiltFactorY = (float)Data.gY * 0.0001f;
+                Data.GyroTiltFactorZ = (float)Data.gZ * 0.0001f * -90;
+                // sensitivity scale factor 4 -> radian/sec
+                Data.calGyroX = Data.gX / 16.4f * deg2rad;
+                Data.calGyroY = Data.gY / 16.4f * deg2rad;
+                Data.calGyroZ = Data.gZ / 16.4f * deg2rad;
+                // sensitivity scale factor 0 -> units/g
+                Data.calAccelX = Data.aX * 1.0f / 16384;
+                Data.calAccelY = Data.aY * 1.0f / 16384;
+                Data.calAccelZ = Data.aZ * 1.0f / 16384;
+
+                double[] eulAnglesYPR = ToEulerAngles(Data.qW, Data.qY, Data.qZ, Data.qX);
+                Data.Yaw = eulAnglesYPR[0] * 2.0f / Math.PI;
+                Data.Pitch = eulAnglesYPR[1] * 2.0f / Math.PI;
+                Data.Roll = -(eulAnglesYPR[2] * 2.0f / Math.PI);
+                if (double.IsNaN(Data.Yaw)) Data.Yaw = 0f;
+                if (double.IsNaN(Data.Pitch)) Data.Pitch = 0f;
+                if (double.IsNaN(Data.Roll)) Data.Roll = 0f;
+
+                // auto-calibrate on the fly over several seconds when near idle
+                calib.Calibrate(
+                    Data.Yaw, Data.Pitch, Data.Roll,
+                    Data.calGyroX, Data.calGyroY, Data.calGyroZ,
+                    Data.calAccelX, Data.calAccelY, Data.calAccelZ
+                );
+                Data.Yaw += calib.OffsetY;
+                Data.Pitch += calib.OffsetP;
+                Data.Roll += calib.OffsetR;
+
+                Data.QuatTiltFactorX = (float)((2 * Math.Abs(Mod((Data.Pitch - 1) * 0.5f, 2) - 1)) - 1);
+                Data.QuatTiltFactorY = (float)((2 * Math.Abs(Mod((Data.Roll - 1) * 0.5f, 2) - 1)) - 1);
+                Data.QuatTiltFactorZ = (float)(Data.Yaw * -90.0f);
+
+                Interlocked.Exchange(ref usingResource, 0);
+            }
+            return Data;
+        }
+
+        // HELPERS
+        public static double[] ToEulerAngles(double QuaternionW, double QuaternionX, double QuaternionY, double QuaternionZ)
+        {
+            double sqw = QuaternionW * QuaternionW;
+            double sqx = QuaternionX * QuaternionX;
+            double sqy = QuaternionY * QuaternionY;
+            double sqz = QuaternionZ * QuaternionZ;
+
+            // If quaternion is normalised the unit is one, otherwise it is the correction factor
+            double unit = sqx + sqy + sqz + sqw;
+            double test = QuaternionX * QuaternionY + QuaternionZ * QuaternionW;
+
+            if (test > 0.4999f * unit)                              // 0.4999f OR 0.5f - EPSILON
+            {
+                // Singularity at north pole
+                return new double[] {
+                    2f * Math.Atan2(QuaternionX, QuaternionW),  // Yaw
+                    Math.PI * 0.5f,                         // Pitch
+                    0f                                // Roll
+                };
+            }
+            else if (test < -0.4999f * unit)                        // -0.4999f OR -0.5f + EPSILON
+            {
+                // Singularity at south pole
+                return new double[] {
+                    -2f * Math.Atan2(QuaternionX, QuaternionW), // Yaw
+                    -Math.PI * 0.5f,                        // Pitch
+                    0f                                // Roll
+                };
+            }
+            else
+            {
+                return new double[] {
+                    Math.Atan2(2f * QuaternionY * QuaternionW - 2f * QuaternionX * QuaternionZ, sqx - sqy - sqz + sqw),       // Yaw
+                    Math.Asin(2f * test / unit),                                             // Pitch
+                    Math.Atan2(2f * QuaternionX * QuaternionW - 2f * QuaternionY * QuaternionZ, -sqx + sqy - sqz + sqw)      // Roll
+                };
+            }
+        }
+
+        public static double Mod(double x, double m)
+        {
+            return (x % m + m) % m;
+        }
+    }
+}

--- a/VSCView/SensorFusion.cs
+++ b/VSCView/SensorFusion.cs
@@ -34,7 +34,7 @@ namespace VSCView
             public double OffsetY { get; private set; }
             public double OffsetP { get; private set; }
             public double OffsetR { get; private set; }
-            const double framerate = 66.6666666667f;
+            const double framerate = 60.0f;
 
             EMACalc velocity;
             int SampleSize, ThresholdCounter;

--- a/VSCView/VSCView.csproj
+++ b/VSCView/VSCView.csproj
@@ -69,6 +69,7 @@
     <Compile Include="ProcForm.Designer.cs">
       <DependentUpon>ProcForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="SensorCollector.cs" />
     <Compile Include="SensorFusion.cs" />
     <Compile Include="SteamController.cs" />
     <Compile Include="RawForm.cs">


### PR DESCRIPTION
This bit of refactoring should take care of most of the performance issues associated with PR #8:

* I've moved as much of the processing and caching of sensor data into a separate thread and helper class as I could without touching the real guts of the GDI+ code. According to profiling this saves about 20% of the overhead.

* I ripped out the unreliable Forms `Timer()` and replaced it with a proper variable render fixed timestep game loop using a high resolution timer (half-step relative to the render cap). As a result, rendering performance should scale smoothly up to 60fps (dependent on the CPU load of the system).

The results of these changes should bring CPU usage from ~20-25% down to around ~5-10% on a low spec device (a 6 year old laptop) while still rendering at 60fps (or around ~1-3% on a modern machine). The rest of the blame for the high CPU usage issues I was having was related to using a different version of the HidLibrary dependency that lacked your rate limited polling changes. My bad.

The only other suggestions for performance improvements I can think of would be to remove as much of the calculations, loops, and transforms from the GDI+ code as possible and put them in another thread tied to the render loop so Paint() only needs to get an already processed (and cached) image then render it. Also, implementing partial invalidation of the rendered control (based on which UI elements are being updated) might also help a bit in reducing the number of paint calls.

Let me know if you spot any bugs I may have introduced with these changes.